### PR TITLE
RUST-1341 Update evergreen configuration to include `libmongocrypt` crate

### DIFF
--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -4,5 +4,5 @@ set -o errexit
 
 source ./.evergreen/configure-rust.sh
 
-cd mongocrypt-sys
+cd $TARGET_DIR
 cargo build

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -51,26 +51,53 @@ pre:
       ${PREPARE_SHELL}
       .evergreen/install-dependencies.sh
 
-tasks:
-- name: "compile-only"
-  commands:
+functions:
+  "compile only":
   - command: shell.exec
     type: test
     params:
       working_dir: "src"
       script: |
         ${PREPARE_SHELL}
-        .evergreen/compile-only.sh
+        TARGET_DIR=${target_dir} .evergreen/compile-only.sh
+  
+  "run tests":
+  - command: shell.exec
+    type: test
+    params:
+      working_dir: "src"
+      script: |
+        ${PREPARE_SHELL}
+        TARGET_DIR=${target_dir} .evergreen/run-tests.sh
+
+tasks:
+- name: "compile-only-sys"
+  tags: ["compile", "sys"]
+  commands:
+  - func: "compile only"
+    vars:
+      target_dir: mongocrypt-sys
+
+- name: "test-sys"
+  tags: ["test", "sys"]
+  commands:
+  - func: "run tests"
+    vars:
+      target_dir: mongocrypt-sys
+
+- name: "compile-only"
+  tags: ["compile"]
+  commands:
+  - func: "compile only"
+    vars:
+      target_dir: mongocrypt
 
 - name: "test"
+  tags: ["test"]
   commands:
-  - command: shell.exec
-    type: test
-    params:
-      working_dir: "src"
-      script: |
-        ${PREPARE_SHELL}
-        .evergreen/run-tests.sh
+  - func: "run tests"
+    vars:
+      target_dir: mongocrypt
 
 buildvariants:
 - name: ubuntu
@@ -79,21 +106,21 @@ buildvariants:
   expansions:
     libmongocrypt_os: "ubuntu1804-64"
   tasks:
-  - name: "compile-only"
-  - name: "test"
+  - name: ".compile"
+  - name: ".test"
 - name: macos
   display_name: "MacOS 10.14"
   run_on: macos-1014
   expansions:
     libmongocrypt_os: "macos"
   tasks:
-  - name: "compile-only"
-  - name: "test"
+  - name: ".sys"
+  - name: ".compile"
 - name: windows
   display_name: "Windows (VS 2017)"
   run_on: windows-64-vs2017-test
   expansions:
     libmongocrypt_os: "windows-test"
   tasks:
-  - name: "compile-only"
-  - name: "test"
+  - name: ".sys"
+  - name: ".compile"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -4,5 +4,5 @@ set -o errexit
 
 source ./.evergreen/configure-rust.sh
 
-cd mongocrypt-sys
+cd $TARGET_DIR
 cargo test

--- a/mongocrypt/src/convert.rs
+++ b/mongocrypt/src/convert.rs
@@ -26,11 +26,9 @@ pub(crate) fn path_bytes(path: &std::path::Path) -> Result<Vec<u8>> {
     // from utf8 to utf16 on that platform.
     use error::Error;
 
-    let s = path.to_str().ok_or_else(|| Error {
-        kind: ErrorKind::Encoding,
-        code: 0,
-        message: Some(format!("could not utf-8 encode path {:?}", path)),
-    })?;
+    let s = path
+        .to_str()
+        .ok_or_else(|| error::encoding!("could not utf-8 encode path {:?}", path))?;
     Ok(s.as_bytes().to_vec())
 }
 


### PR DESCRIPTION
RUST-1341

This updates the evergreen configuration to run build and tests for both `libmongocrypt-sys` and `libmongocrypt`.  Full tests for the latter are only run on one build target (somewhat arbitrarily ubuntu).

Also fixes a Windows bug this configuration made visible :)  The remaining compile failure is fixed by #4.