### PR TITLE
RUST-1384 Move all `Ctx` actions to a dedicated worker thread

### DIFF
--- a/mongocrypt/Cargo.toml
+++ b/mongocrypt/Cargo.toml
@@ -18,6 +18,8 @@ compile_fail = []
 [dependencies]
 mongocrypt-sys = { path = "../mongocrypt-sys" }
 bson = { git = "https://github.com/mongodb/bson-rust", branch = "main" }
+tokio = { version = "1.20", features = ["rt"], optional = true }
+async-std = { version = "1.12", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.81"

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -663,6 +663,9 @@ pub struct KmsScope<'ctx> {
     ctx: &'ctx Ctx,
 }
 
+// This is `Iterator`-like but does not impl that because it's encouraged for multiple `KmsCtx` to
+// be retrieved and processed in parallel, as reflected in the `&self` shared reference rather than
+// `Iterator`'s exclusive `next(&mut self)`.
 impl<'ctx> KmsScope<'ctx> {
     /// Get the next KMS handle.
     ///

--- a/mongocrypt/src/error.rs
+++ b/mongocrypt/src/error.rs
@@ -189,11 +189,11 @@ impl Status {
 pub(crate) trait HasStatus {
     unsafe fn native_status(&self, status: *mut sys::mongocrypt_status_t);
 
-    fn status(&self) -> Status {
+    fn error(&self) -> Error {
         let out = Status::new();
         unsafe {
             self.native_status(*out.native());
         }
-        out
+        out.as_error()
     }
 }

--- a/mongocrypt/src/hooks.rs
+++ b/mongocrypt/src/hooks.rs
@@ -47,7 +47,7 @@ impl CryptBuilder {
                 Some(log_shim),
                 handler_ptr,
             ) {
-                return Err(self.status().as_error());
+                return Err(self.error());
             }
         }
 
@@ -113,7 +113,7 @@ impl CryptBuilder {
                 Some(sha_256_shim),
                 &*hooks as *const CryptoHooks as *mut std::ffi::c_void,
             ) {
-                return Err(self.status().as_error());
+                return Err(self.error());
             }
         }
         self.cleanup.push(hooks);
@@ -190,7 +190,7 @@ impl CryptBuilder {
                 Some(aes_256_ctr_decrypt_shim),
                 &*hooks as *const Hooks as *mut std::ffi::c_void,
             ) {
-                return Err(self.status().as_error());
+                return Err(self.error());
             }
         }
         self.cleanup.push(hooks);
@@ -227,7 +227,7 @@ impl CryptBuilder {
                 Some(shim),
                 &*hook as *const CryptoFn as *mut std::ffi::c_void,
             ) {
-                return Err(self.status().as_error());
+                return Err(self.error());
             }
         }
         self.cleanup.push(hook);
@@ -262,7 +262,7 @@ impl CryptBuilder {
                 Some(shim),
                 &*hook as *const HmacFn as *mut std::ffi::c_void,
             ) {
-                return Err(self.status().as_error());
+                return Err(self.error());
             }
         }
         self.cleanup.push(hook);

--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -4,7 +4,7 @@ use bson::Document;
 #[cfg(test)]
 use convert::str_bytes_len;
 use convert::{doc_binary, path_bytes};
-use ctx::{CtxBuilder, Ctx, BuiltCtx};
+use ctx::{BuiltCtx, Ctx, CtxBuilder};
 use mongocrypt_sys as sys;
 
 mod binary;
@@ -283,7 +283,10 @@ impl Crypt {
         Some(out)
     }
 
-    pub fn build_ctx(&self, f: impl FnOnce(CtxBuilder) -> Result<BuiltCtx> + Send + 'static) -> Result<Ctx> {
-        Ctx::build(&self, f)
+    pub fn build_ctx(
+        &self,
+        f: impl FnOnce(CtxBuilder) -> Result<BuiltCtx> + Send + 'static,
+    ) -> Result<Ctx> {
+        Ctx::build(self, f)
     }
 }

--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -4,7 +4,7 @@ use bson::Document;
 #[cfg(test)]
 use convert::str_bytes_len;
 use convert::{doc_binary, path_bytes};
-use ctx::CtxBuilder;
+use ctx::{CtxBuilder, Ctx};
 use mongocrypt_sys as sys;
 
 mod binary;
@@ -283,7 +283,7 @@ impl Crypt {
         Some(out)
     }
 
-    pub fn ctx_builder(&self) -> CtxBuilder {
-        CtxBuilder::steal(unsafe { sys::mongocrypt_ctx_new(*self.inner.borrow()) })
+    pub fn build_ctx(&self, f: impl FnOnce(CtxBuilder) -> Result<Ctx> + Send + 'static) -> Result<Ctx> {
+        Ctx::build(&self, f)
     }
 }

--- a/mongocrypt/src/test.rs
+++ b/mongocrypt/src/test.rs
@@ -60,17 +60,19 @@ fn ctx_setopts() -> Result<()> {
         .kms_provider_aws("example", "example")?
         .build()?;
 
-    let builder = crypt.ctx_builder();
-    builder
-        .key_id(&[0; 16])?
-        .key_alt_name("test")?
-        .key_material(&[0; 96])?
-        .algorithm(Algorithm::AeadAes256CbcHmacSha512Deterministic)?
-        .masterkey_aws("somewhere", "something")?
-        .masterkey_aws_endpoint("example.com")?
-        .contention_factor(10)?
-        .index_key_id(&bson::Uuid::new())?
-        .query_type("equality")?;
+    let ctx = crypt.build_ctx(|builder| {
+        builder
+            .key_id(&[0; 16])?
+            .key_alt_name("test")?
+            .key_material(&[0; 96])?
+            .algorithm(Algorithm::AeadAes256CbcHmacSha512Deterministic)?
+            .masterkey_aws("somewhere", "something")?
+            .masterkey_aws_endpoint("example.com")?
+            .contention_factor(10)?
+            .index_key_id(&bson::Uuid::new())?
+            .query_type("equality")?
+            .build_noop()
+    })?;
 
     Ok(())
 }

--- a/mongocrypt/src/test.rs
+++ b/mongocrypt/src/test.rs
@@ -60,7 +60,7 @@ fn ctx_setopts() -> Result<()> {
         .kms_provider_aws("example", "example")?
         .build()?;
 
-    let ctx = crypt.build_ctx(|builder| {
+    crypt.build_ctx(|builder| {
         builder
             .key_id(&[0; 16])?
             .key_alt_name("test")?

--- a/mongocrypt/src/test/example_state_machine.rs
+++ b/mongocrypt/src/test/example_state_machine.rs
@@ -140,25 +140,21 @@ fn explicit_encryption_decryption() -> Result<()> {
 
     // Encryption
     let key_doc = load_doc_from_json("../testdata/key-document.json");
-    let mut ctx = crypt.build_ctx(move |builder|
-        {
-            let key_bytes = match key_doc.get("_id").unwrap() {
-                Bson::Binary(bson::Binary { bytes, .. }) => bytes,
-                _ => panic!("non-binary bson"),
-            };        
-            builder
-                .key_id(key_bytes)?
-                .algorithm(Algorithm::AeadAes256CbcHmacSha512Random)?
-                .build_explicit_encrypt(RawBson::String("hello".to_string()))
-        }
-    )?;
+    let mut ctx = crypt.build_ctx(move |builder| {
+        let key_bytes = match key_doc.get("_id").unwrap() {
+            Bson::Binary(bson::Binary { bytes, .. }) => bytes,
+            _ => panic!("non-binary bson"),
+        };
+        builder
+            .key_id(key_bytes)?
+            .algorithm(Algorithm::AeadAes256CbcHmacSha512Random)?
+            .build_explicit_encrypt(RawBson::String("hello".to_string()))
+    })?;
     let result = run_state_machine(&mut ctx)?;
 
     // Decryption
-    let mut ctx = crypt.build_ctx(move |builder|
-        builder
-            .build_explicit_decrypt(result.as_bytes())
-    )?;
+    let mut ctx =
+        crypt.build_ctx(move |builder| builder.build_explicit_decrypt(result.as_bytes()))?;
     run_state_machine(&mut ctx)?;
 
     Ok(())


### PR DESCRIPTION
RUST-1384

The [libmongocrypt documentation](https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h#L293) specifies that functions on `mongocrypt_ctx_t` are not threadsafe and must be owned by a single thread.  This is easily expressable in the Rust type system - just make `Ctx` not `Send` - but that turns out to be a major issue for using it in async code, as any future that holds a `Ctx` across an `.await` point itself becomes itself non-`Send`, which means it basically can't be invoked (this is a very handwavy oversimplification, but it is the practical outcome).

This refactor creates a dedicated worker loop bound to the lifetime of the rust `Ctx` value; actions are performed by sending it closures to execute that operate directly on the raw pointer.  This keeps the Rust lifetime annotations on the "outside" of the thread boundary, which allows values produced to be shared rather than copied.  The major downside heres are:
* The cost of boxing the closures; those are small (captured context is just a few pointers) so that shouldn't be a substantial factor.
* Latency introduced by the channel.  This seems unavoidable, as any situation with a dedicated thread and async code is going to need something channel-like.

