### PR TITLE
RUST-1384 Impl Send for Ctx

### DIFF
--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -355,6 +355,8 @@ pub struct Ctx {
     inner: OwnedPtr<sys::mongocrypt_ctx_t>,
 }
 
+unsafe impl Send for Ctx {}
+
 impl HasStatus for Ctx {
     unsafe fn native_status(&self, status: *mut sys::mongocrypt_status_t) {
         sys::mongocrypt_ctx_status(*self.inner.borrow(), status);
@@ -523,6 +525,9 @@ impl State {
 pub struct KmsScope<'ctx> {
     ctx: &'ctx Ctx,
 }
+
+unsafe impl<'ctx> Send for KmsScope<'ctx> {}
+unsafe impl<'ctx> Sync for KmsScope<'ctx> {}
 
 // This is `Iterator`-like but does not impl that because it's encouraged for multiple `KmsCtx` to
 // be retrieved and processed in parallel, as reflected in the `&self` shared reference rather than

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -355,6 +355,7 @@ pub struct Ctx {
     inner: OwnedPtr<sys::mongocrypt_ctx_t>,
 }
 
+// Functions on `mongocrypt_ctx_t` are not threadsafe but do not rely on any thread-local state, so `Ctx` is `Send` but not `Sync.
 unsafe impl Send for Ctx {}
 
 impl HasStatus for Ctx {
@@ -526,6 +527,7 @@ pub struct KmsScope<'ctx> {
     ctx: &'ctx Ctx,
 }
 
+// Handling multiple KMS requests is threadsafe, so `KmsScope` can be both `Send` and `Sync`.
 unsafe impl<'ctx> Send for KmsScope<'ctx> {}
 unsafe impl<'ctx> Sync for KmsScope<'ctx> {}
 


### PR DESCRIPTION
RUST-1384

Patrick tracked down the actual thread properties of `mongocrypt_ctx_t` and happily it's not as restrictive as the docs make it seem 🙂 

Usage also requires `Send` and `Sync` for the `KmsScope` type; those should have been there before, as fanning out `mongocrypt_kms_ctx_t` requests is explicitly threadsafe.