### PR TITLE
RUST-1386 Add serde support for KmsProvider

### DIFF
--- a/mongocrypt/Cargo.toml
+++ b/mongocrypt/Cargo.toml
@@ -18,6 +18,7 @@ compile_fail = []
 [dependencies]
 mongocrypt-sys = { path = "../mongocrypt-sys" }
 bson = { git = "https://github.com/mongodb/bson-rust", branch = "main" }
+serde = "1.0.125"
 
 [dev-dependencies]
 serde_json = "1.0.81"


### PR DESCRIPTION
RUST-1386

This implements `[De]Serialize` for `KmsProvider`, which is particularly useful when loading configurations from json.  It also adds the accidentally omitted `KmsProvider::Local`.