### PR TITLE
RUST-1578 Force crypt initialization to be sequential

### DIFF
--- a/mongocrypt/Cargo.toml
+++ b/mongocrypt/Cargo.toml
@@ -20,6 +20,7 @@ compile_fail = []
 mongocrypt-sys = { path = "../mongocrypt-sys" }
 bson = { git = "https://github.com/mongodb/bson-rust", branch = "main" }
 serde = "1.0.125"
+once_cell = "1.17.0"
 
 [dev-dependencies]
 serde_json = "1.0.81"

--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -39,6 +39,7 @@ impl HasStatus for CryptBuilder {
     }
 }
 
+// This works around a possible race condition in mongocrypt [de]initialization; see RUST-1578 for details.
 static CRYPT_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 unsafe extern "C" fn mongocrypt_destroy_locked(crypt: *mut sys::mongocrypt_t) {


### PR DESCRIPTION
RUST-1578

This is a speculative fix; I can't reproduce the failure with high enough success rate to instrument it.

Following the theory that there's a race condition between one instance of `mongocrypt_t` being destroyed and another being initialized, this forces both of them to be strictly sequential via a shared lock.  Neither method does any heavy lifting or I/O, and these are each only called once per `Client` lifetime, so any performance impact of this should be all but invisible.

