### PR TITLE
RUST-1605 Update libmongocrypt with fle2v2 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Rust language bindings for the [libmongocrypt](https://github.com/mongodb/libmon
 
 # Requirements
 
-libmongocrypt 1.5.0 or higher must be installed; if it's not in a system-default location `MONGOCRYPT_LIB_DIR` can be set to specify a search location.
+libmongocrypt 1.8.0 or higher must be installed; if it's not in a system-default location `MONGOCRYPT_LIB_DIR` can be set to specify a search location.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,7 @@
 # Publishing new crate versions
 New versions of both the `mongocrypt-sys` and `mongocrypt` crates can be released with the `publish.sh` script; they do not have to be released in lockstep, although API changes in `mongocrypt-sys` will probably require changes in `mongocrypt` as well.
 
+1. When publishing the `mongocrypt-sys` crate, along with normal version increment include the version of `libmongocrypt` the bindings were generated against, e.g. increment from `"0.1.0+1.6.1"` to `"0.1.1+1.8.0"`.
 1. When publishing the `mongocrypt` crate, push a change updating the `mongocrypt-sys` and `bson` dependencies to the most recent published versions.
 1. Create a tag combining the crate name and version to be published, e.g. `mongocrypt-sys-0.1`.  If pushing both crates, create two tags (they can point to the same commit).
 1. Push the tag(s) upstream.

--- a/mongocrypt-sys/Cargo.toml
+++ b/mongocrypt-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mongocrypt-sys"
 description = "FFI bindings to libmongocrypt"
-version = "0.1.0+1.6.1"
+version = "0.1.1+1.8.0-alpha0"
 edition = "2021"
 license = "Apache-2.0"
 authors = [

--- a/mongocrypt-sys/src/bindings.rs
+++ b/mongocrypt-sys/src/bindings.rs
@@ -110,6 +110,10 @@ extern "C" {
     pub fn mongocrypt_new() -> *mut mongocrypt_t;
 }
 extern "C" {
+    #[doc = " Enable/disable the use of FLE2v2 payload types for write.\n\n @param[in] crypt The @ref mongocrypt_t object.\n @param[in] enable Whether to enable use of FLE2v2 payloads.\n\n @returns A boolean indicating success. If false, an error status is set.\n Retrieve it with @ref mongocrypt_status"]
+    pub fn mongocrypt_setopt_fle2v2(crypt: *mut mongocrypt_t, enable: bool) -> bool;
+}
+extern "C" {
     #[doc = " Set a handler on the @ref mongocrypt_t object to get called on every log\n message.\n\n @param[in] crypt The @ref mongocrypt_t object.\n @param[in] log_fn The log callback.\n @param[in] log_ctx A context passed as an argument to the log callback every\n invocation.\n @pre @ref mongocrypt_init has not been called on @p crypt.\n @returns A boolean indicating success. If false, an error status is set.\n Retrieve it with @ref mongocrypt_ctx_status"]
     pub fn mongocrypt_setopt_log_handler(
         crypt: *mut mongocrypt_t,

--- a/mongocrypt/Cargo.toml
+++ b/mongocrypt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mongocrypt"
 description = "Rust-idiomatic wrapper around mongocrypt-sys"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = [

--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -224,6 +224,16 @@ impl CryptBuilder {
         self
     }
 
+    /// Enable/disable the use of FLE2v2 payload types for write.
+    pub fn fle2v2(self, enable: bool) -> Result<Self> {
+        unsafe {
+            if !sys::mongocrypt_setopt_fle2v2(*self.inner.borrow(), enable) {
+                return Err(self.status().as_error());
+            }
+        }
+        Ok(self)
+    }
+
     pub fn build(mut self) -> Result<Crypt> {
         let _guard = CRYPT_LOCK.lock().unwrap();
 


### PR DESCRIPTION
RUST-1605

I also updated the release instructions to clarify how version bumps should work.