### PR TITLE
RUST-1952 Use `std::ffi::c_char` instead of `*const i8`

### DIFF
--- a/mongocrypt/src/convert.rs
+++ b/mongocrypt/src/convert.rs
@@ -32,9 +32,9 @@ pub(crate) fn path_bytes(path: &std::path::Path) -> Result<Vec<u8>> {
     Ok(s.as_bytes().to_vec())
 }
 
-pub(crate) fn str_bytes_len(s: &str) -> Result<(*const i8, i32)> {
+pub(crate) fn str_bytes_len(s: &str) -> Result<(*const std::ffi::c_char, i32)> {
     Ok((
-        s.as_bytes().as_ptr() as *const i8,
+        s.as_bytes().as_ptr() as *const std::ffi::c_char,
         s.as_bytes().len().try_into()?,
     ))
 }

--- a/mongocrypt/src/hooks.rs
+++ b/mongocrypt/src/hooks.rs
@@ -360,7 +360,8 @@ fn write_status(result: Result<()>, c_status: *mut sys::mongocrypt_status_t) -> 
                 c_status,
                 sys::mongocrypt_status_type_t_MONGOCRYPT_STATUS_ERROR_CLIENT,
                 0,
-                b"Failed to record error, see logs for details\0".as_ptr() as *const i8,
+                b"Failed to record error, see logs for details\0".as_ptr()
+                    as *const std::ffi::c_char,
                 -1,
             );
         }

--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, ffi::CStr, path::Path, ptr, sync::Mutex};
 use bson::Document;
 #[cfg(test)]
 use convert::str_bytes_len;
-use convert::{doc_binary, path_bytes};
+use convert::{doc_binary, path_cstring};
 use ctx::CtxBuilder;
 use mongocrypt_sys as sys;
 
@@ -155,12 +155,11 @@ impl CryptBuilder {
     /// `set_crypt_shared_lib_path_override`, then paths
     /// appended here will have no effect.
     pub fn append_crypt_shared_lib_search_path(self, path: &Path) -> Result<Self> {
-        let mut tmp = path_bytes(path)?;
-        tmp.push(0);
+        let tmp = path_cstring(path)?;
         unsafe {
             sys::mongocrypt_setopt_append_crypt_shared_lib_search_path(
                 *self.inner.borrow(),
-                tmp.as_ptr() as *const i8,
+                tmp.as_ptr(),
             );
         }
         Ok(self)
@@ -184,12 +183,11 @@ impl CryptBuilder {
     /// initialize a valid crypt_shared library instance for the path specified, then
     /// the initialization will fail with an error.
     pub fn set_crypt_shared_lib_path_override(self, path: &Path) -> Result<Self> {
-        let mut tmp = path_bytes(path)?;
-        tmp.push(0);
+        let tmp = path_cstring(path)?;
         unsafe {
             sys::mongocrypt_setopt_set_crypt_shared_lib_path_override(
                 *self.inner.borrow(),
-                tmp.as_ptr() as *const i8,
+                tmp.as_ptr(),
             );
         }
         Ok(self)


### PR DESCRIPTION
RUST-1952

The C character type might be signed or unsigned depending on the system; without this fix the bindings failed to compile on systems where it's unsigned.