### PR TITLE
RUST-1813 Support named KMS providers

### DIFF
--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -756,16 +756,47 @@ pub enum KmsProviderType {
     Other(String),
 }
 
-impl From<KmsProviderType> for KmsProvider {
-    fn from(provider_type: KmsProviderType) -> Self {
-        KmsProvider {
-            provider_type,
+impl KmsProvider {
+    pub fn aws() -> Self {
+        Self {
+            provider_type: KmsProviderType::Aws,
+            name: None,
+        }
+    }
+
+    pub fn azure() -> Self {
+        Self {
+            provider_type: KmsProviderType::Azure,
+            name: None,
+        }
+    }
+
+    pub fn gcp() -> Self {
+        Self {
+            provider_type: KmsProviderType::Gcp,
+            name: None,
+        }
+    }
+
+    pub fn local() -> Self {
+        Self {
+            provider_type: KmsProviderType::Local,
             name: None
         }
     }
-}
 
-impl KmsProvider {
+    pub fn other(other: String) -> Self {
+        Self {
+            provider_type: KmsProviderType::Other(other),
+            name: None,
+        }
+    }
+
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
     pub fn name(&self) -> String {
         let mut full_name = match self.provider_type {
             KmsProviderType::Aws => "aws",

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -792,8 +792,8 @@ impl KmsProvider {
         }
     }
 
-    pub fn with_name(mut self, name: String) -> Self {
-        self.name = Some(name);
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
         self
     }
 

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -785,9 +785,9 @@ impl KmsProvider {
         }
     }
 
-    pub fn other(other: String) -> Self {
+    pub fn other(other: impl Into<String>) -> Self {
         Self {
-            provider_type: KmsProviderType::Other(other),
+            provider_type: KmsProviderType::Other(other.into()),
             name: None,
         }
     }

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -735,15 +735,14 @@ impl<'scope> KmsCtx<'scope> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[non_exhaustive]
 pub struct KmsProvider {
     /// The type of KMS provider to use.
-    provider_type: KmsProviderType,
+    pub provider_type: KmsProviderType,
 
     /// The name of the KMS provider. This value can be set in order to use multiple KMS providers
     /// of the same type in one KMS provider list. If set, a name must also be set for all other
     /// KMS providers of the same type in a list.
-    name: Option<String>,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -785,6 +785,13 @@ impl KmsProvider {
         }
     }
 
+    pub fn kmip() -> Self {
+        Self {
+            provider_type: KmsProviderType::Kmip,
+            name: None,
+        }
+    }
+
     pub fn other(other: impl Into<String>) -> Self {
         Self {
             provider_type: KmsProviderType::Other(other.into()),

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -734,17 +734,16 @@ impl<'scope> KmsCtx<'scope> {
     }
 }
 
+/// A KMS provider. KMS providers can be constructed using the various constructors that correspond
+/// to each [`KmsProviderType`]. KMS providers also have an optional name that can be set using the
+/// [`with_name`](KmsProvider::with_name) method.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KmsProvider {
-    /// The type of KMS provider to use.
     provider_type: KmsProviderType,
-
-    /// The name of the KMS provider. This value can be set in order to use multiple KMS providers
-    /// of the same type in one KMS provider list. If set, a name must also be set for all other
-    /// KMS providers of the same type in a list.
     name: Option<String>,
 }
 
+/// The supported KMS provider types.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum KmsProviderType {
@@ -757,6 +756,7 @@ pub enum KmsProviderType {
 }
 
 impl KmsProvider {
+    /// Constructs an unnamed AWS KMS provider.
     pub fn aws() -> Self {
         Self {
             provider_type: KmsProviderType::Aws,
@@ -764,6 +764,7 @@ impl KmsProvider {
         }
     }
 
+    /// Constructs an unnamed Azure KMS provider.
     pub fn azure() -> Self {
         Self {
             provider_type: KmsProviderType::Azure,
@@ -771,6 +772,7 @@ impl KmsProvider {
         }
     }
 
+    /// Constructs an unnamed GCP KMS provider.
     pub fn gcp() -> Self {
         Self {
             provider_type: KmsProviderType::Gcp,
@@ -778,6 +780,7 @@ impl KmsProvider {
         }
     }
 
+    /// Constructs an unnamed local KMS provider.
     pub fn local() -> Self {
         Self {
             provider_type: KmsProviderType::Local,
@@ -785,6 +788,7 @@ impl KmsProvider {
         }
     }
 
+    /// Constructs an unnamed KMIP KMS provider.
     pub fn kmip() -> Self {
         Self {
             provider_type: KmsProviderType::Kmip,
@@ -792,6 +796,7 @@ impl KmsProvider {
         }
     }
 
+    /// Constructs an unnamed KMS provider with the given string.
     pub fn other(other: impl Into<String>) -> Self {
         Self {
             provider_type: KmsProviderType::Other(other.into()),
@@ -799,19 +804,24 @@ impl KmsProvider {
         }
     }
 
+    /// Sets the given name on this KMS provider. A name can be set to use multiple KMS providers
+    /// of the same type in one KMS provider list.
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
+    /// This KMS provider's type.
     pub fn provider_type(&self) -> &KmsProviderType {
         &self.provider_type
     }
 
+    /// The name for this KMS provider.
     pub fn name(&self) -> Option<&String> {
         self.name.as_ref()
     }
 
+    /// Returns the string representation of this KMS provider.
     pub fn as_string(&self) -> String {
         let mut full_name = match self.provider_type {
             KmsProviderType::Aws => "aws",
@@ -828,6 +838,8 @@ impl KmsProvider {
         full_name
     }
 
+    /// Constructs a KMS provider from the given string. The string must begin with the provider
+    /// type followed by an optional ":" and name, e.g. "aws" or "aws:name".
     pub fn from_string(name: &str) -> Self {
         let (provider_type, name) = match name.split_once(':') {
             Some((provider_type, name)) => {


### PR DESCRIPTION
The API changes here deviate a bit from the proposal in the doc. Using `From` impls/direct construction would require this for an unnamed provider:

```
let provider: KmsProvider = KmsProviderType::Aws.into();
```

and this for a named provider:

```
let provider = KmsProvider {
    provider_type: KmsProviderType::Aws,
    name: Some("name".to_string()),
};
```

A `TypedBuilder` impl seemed like overkill, so I converted `KmsProvider` to an opaque type with constructor methods:

```
let provider = KmsProvider::aws();
```

with a builder-style method to add a name:

```
let provider = KmsProvider::aws().with_name("name");
```

The name/provider type can still be accessed via accessor methods. In the (probably unlikely) event that we add anything else to this type, we can just add another `with_<field>` method and accessor.

I also switched the methods that use "name" to use "string" instead, as "name" now means something different for this type.