### PR TITLE
minor: fix release script and instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,13 +5,16 @@ New versions of both the `mongocrypt-sys` and `mongocrypt` crates can be release
 1. When publishing the `mongocrypt` crate, push a change updating the `mongocrypt-sys` and `bson` dependencies to the most recent published versions.
 1. Create a tag combining the crate name and version to be published, e.g. `mongocrypt-sys-0.1`.  If pushing both crates, create two tags (they can point to the same commit).
 1. Push the tag(s) upstream.
-1. Run the publish script with the `VERSION`, `TOKEN`, and `CRATE` variables:
+1. Run the publish script:
 
+        CRATE=<mongocrypt | mongocrypt-sys> \
         VERSION=<version to be published> \
+        # The following should be retreived from the driver secrets:
         TOKEN=<crates.io auth token> \
         ARTIFACTORY_USERNAME=<artifactory username> \
         ARTIFACTORY_PASSWORD=<artifactory password> \
         GARASIGN_USERNAME=<garasign username> \
         GARASIGN_PASSWORD=<garasign password> \
-        CRATE=<mongocrypt | mongocrypt-sys> \
+        AWS_ACCESS_KEY_ID=<s3 upload aws key> \
+        AWS_SECRET_ACCESS_KEY=<s3 upload aws secret> \
         ./publish.sh

--- a/publish.sh
+++ b/publish.sh
@@ -24,6 +24,7 @@ git checkout $CRATE-$VERSION
 
 cd $CRATE
 cargo publish --token $TOKEN "$@"
-$(dirname $0)/.evergreen/sign-release.sh
+../.evergreen/sign-release.sh
+aws s3 cp $CRATE-$VERSION.sig s3://cdn-origin-rust-driver/rust-driver/
 
 git checkout main


### PR DESCRIPTION
This fixes the script to properly execute the signing script and actually upload the resulting signatures to the s3 bucket.  It also updates the instructions to include all the relevant variables needed and more clearly indicate which are specifying the publish parameters and which are secrets.