### PR TITLE
RUST-2195 add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Listing code owners is required by DRIVERS-3098
+* @mongodb/dbx-rust


### PR DESCRIPTION
To meet requirement of DRIVERS-3098. Follow-up to https://github.com/mongodb/mongo-rust-driver/pull/1359.

