### PR TITLE
RUST-1907 Add separate buildvariants for lint and compile

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -102,7 +102,6 @@ tasks:
       target_dir: mongocrypt
 
 - name: "valgrind"
-  tags: ["lint"]
   commands:
   - command: shell.exec
     type: test
@@ -148,6 +147,7 @@ buildvariants:
   tasks:
     # compilation on ubuntu is tested in the compile build variant
   - name: ".test"
+  - name: "valgrind"
 
 - name: macos
   display_name: "MacOS 10.14"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -62,7 +62,7 @@ functions:
       script: |
         ${PREPARE_SHELL}
         TARGET_DIR=${target_dir} .evergreen/compile-only.sh
-  
+
   "run tests":
   - command: shell.exec
     type: test
@@ -102,6 +102,7 @@ tasks:
       target_dir: mongocrypt
 
 - name: "valgrind"
+  tags: ["lint"]
   commands:
   - command: shell.exec
     type: test
@@ -112,6 +113,7 @@ tasks:
         .evergreen/run-valgrind.sh
 
 - name: "semgrep"
+  tags: ["lint"]
   commands:
     - command: shell.exec
       type: test
@@ -122,16 +124,31 @@ tasks:
           .evergreen/check-semgrep.sh
 
 buildvariants:
+- name: lint
+  display_name: "Lint"
+  run_on: ubuntu1804-test
+  expansions:
+    libmongocrypt_os: "ubuntu1804-64"
+  tasks:
+    - name: .lint
+
+- name: compile
+  display_name: "Compile"
+  run_on: ubuntu1804-test
+  expansions:
+    libmongocrypt_os: "ubuntu1804-64"
+  tasks:
+    - name: .compile
+
 - name: ubuntu
   display_name: "Ubuntu 18.04"
   run_on: ubuntu1804-test
   expansions:
     libmongocrypt_os: "ubuntu1804-64"
   tasks:
-  - name: ".compile"
+    # compilation on ubuntu is tested in the compile build variant
   - name: ".test"
-  - name: "valgrind"
-  - name: "semgrep"
+
 - name: macos
   display_name: "MacOS 10.14"
   run_on: macos-1014
@@ -140,6 +157,7 @@ buildvariants:
   tasks:
   - name: ".sys"
   - name: ".compile"
+
 - name: windows
   display_name: "Windows (VS 2017)"
   run_on: windows-64-vs2017-test

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -18,6 +18,15 @@ fi
 
 curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path $DEFAULT_HOST_OPTIONS
 
+# Cygwin has a bug with reporting symlink paths that breaks rustup; see
+# https://github.com/rust-lang/rustup/issues/4239.  This works around it by replacing the
+# symlinks with copies.
+if [ "Windows_NT" == "$OS" ]; then
+  pushd ${CARGO_HOME}/bin
+  python3 ../../.evergreen/unsymlink.py
+  popd
+fi
+
 # This file is not created by default on Windows
 echo 'export PATH="$PATH:${CARGO_HOME}/bin"' >> ${CARGO_HOME}/env
 echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ${CARGO_HOME}/env

--- a/.evergreen/unsymlink.py
+++ b/.evergreen/unsymlink.py
@@ -1,0 +1,19 @@
+import os
+import shutil
+
+found = []
+for entry in os.scandir():
+    if not entry.is_symlink():
+        print(f"Skipping {entry.name}: not a symlink")
+        continue
+    target = os.readlink(entry.name)
+    if target != "rustup.exe":
+        print(f"Skipping {entry.name}: not rustup.exe")
+        continue
+    print(f"Found {entry.name}")
+    found.append(entry.name)
+
+for name in found:
+    print(f"Replacing {name} symlink with copy")
+    os.remove(name)
+    shutil.copy2("rustup.exe", name)


### PR DESCRIPTION
Refactors lint and compilation tasks into their own buildvariants. These two checks have been set as required to pass for a PR to be able to be merged. I filed RUST-2207 to investigate the valgrind failure. Also pulled in the Windows installation fix.