### PR TITLE
Upgrade MacOS evergreen hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -150,8 +150,8 @@ buildvariants:
   - name: "valgrind"
 
 - name: macos
-  display_name: "MacOS 14.00"
-  run_on: macos-14
+  display_name: "MacOS 11"
+  run_on: macos-11
   expansions:
     libmongocrypt_os: "macos"
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -150,8 +150,8 @@ buildvariants:
   - name: "valgrind"
 
 - name: macos
-  display_name: "MacOS 10.14"
-  run_on: macos-1014
+  display_name: "MacOS 14.00"
+  run_on: macos-14
   expansions:
     libmongocrypt_os: "macos"
   tasks:


### PR DESCRIPTION
The MacOS tests haven't been running since January, when the 10.14 hosts were removed. I tried bumping up to MacOS 14, but got [linker errors](https://spruce.mongodb.com/task/libmongocrypt_rust_macos_test_sys_patch_7e0bd0746dd5b72984f5d7100db9d98f346db4b7_681244083b30f50007603801_25_04_30_15_38_57/logs?execution=0), which seems to be a known issue (https://github.com/mongodb/libmongocrypt/pull/912).