### PR TITLE
RUST-2217 Add optional bson 3.0 support to libmongocrypt-rust

### DIFF
--- a/mongocrypt/Cargo.toml
+++ b/mongocrypt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mongocrypt"
 description = "Rust-idiomatic wrapper around mongocrypt-sys"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 authors = [
@@ -15,11 +15,13 @@ repository = "https://github.com/mongodb/libmongocrypt-rust"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["bson-2"]
 compile_fail = []
 
 [dependencies]
 mongocrypt-sys = { path = "../mongocrypt-sys", version = "0.1.4" }
-bson = { git = "https://github.com/mongodb/bson-rust", branch = "main", version = "2.13.0" }
+bson-2 = { git = "https://github.com/mongodb/bson-rust", branch = "2.15.x", package = "bson", version = "2.13.0", optional = true }
+bson-3 = { git = "https://github.com/mongodb/bson-rust", branch = "main", package = "bson", version = "3.0.0", optional = true }
 serde = "1.0.125"
 once_cell = "1.17.0"
 

--- a/mongocrypt/src/binary.rs
+++ b/mongocrypt/src/binary.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use bson::RawDocumentBuf;
+use crate::bson::RawDocumentBuf;
 use mongocrypt_sys as sys;
 
 use crate::convert::binary_bytes;

--- a/mongocrypt/src/convert.rs
+++ b/mongocrypt/src/convert.rs
@@ -1,6 +1,6 @@
 use std::ffi::CString;
 
-use bson::{Document, RawDocument};
+use crate::bson::{Document, RawDocument};
 use mongocrypt_sys as sys;
 
 use crate::{

--- a/mongocrypt/src/ctx.rs
+++ b/mongocrypt/src/ctx.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Borrow, ffi::CStr, marker::PhantomData, ptr};
 
-use bson::{rawdoc, Document, RawDocument};
+use crate::bson::{rawdoc, Document, RawDocument};
 use mongocrypt_sys as sys;
 use serde::{Deserialize, Serialize};
 
@@ -68,8 +68,8 @@ impl CtxBuilder {
     ///
     /// * `key_material` - The data encryption key to use.
     pub fn key_material(self, key_material: &[u8]) -> Result<Self> {
-        let bson_bin = bson::Binary {
-            subtype: bson::spec::BinarySubtype::Generic,
+        let bson_bin = crate::bson::Binary {
+            subtype: crate::bson::spec::BinarySubtype::Generic,
             bytes: key_material.to_vec(),
         };
         let mut bin: BinaryBuf = rawdoc! { "keyMaterial": bson_bin }.into();
@@ -212,7 +212,7 @@ impl CtxBuilder {
     /// If the index key id not set, the key id from `key_id` is used.
     ///
     /// * `key_id` - The _id (a UUID) of the data key to use from the key vault collection.
-    pub fn index_key_id(self, key_id: &bson::Uuid) -> Result<Self> {
+    pub fn index_key_id(self, key_id: &crate::bson::Uuid) -> Result<Self> {
         let bytes = key_id.bytes();
         let bin = BinaryRef::new(&bytes);
         unsafe {
@@ -298,7 +298,7 @@ impl CtxBuilder {
     /// are set.
     ///
     /// * `value` - the plaintext BSON value.
-    pub fn build_explicit_encrypt(self, value: bson::RawBson) -> Result<Ctx> {
+    pub fn build_explicit_encrypt(self, value: crate::bson::RawBson) -> Result<Ctx> {
         let mut bin: BinaryBuf = rawdoc! { "v": value }.into();
         unsafe {
             if !sys::mongocrypt_ctx_explicit_encrypt_init(*self.inner.borrow(), *bin.native()) {
@@ -341,7 +341,10 @@ impl CtxBuilder {
     ///
     /// An error is returned if FLE 1 and Queryable Encryption incompatible options
     /// are set.
-    pub fn build_explicit_encrypt_expression(self, value: bson::RawDocumentBuf) -> Result<Ctx> {
+    pub fn build_explicit_encrypt_expression(
+        self,
+        value: crate::bson::RawDocumentBuf,
+    ) -> Result<Ctx> {
         let mut bin: BinaryBuf = rawdoc! { "v": value }.into();
         unsafe {
             if !sys::mongocrypt_ctx_explicit_encrypt_expression_init(
@@ -371,8 +374,8 @@ impl CtxBuilder {
     ///
     /// * `msg` - the encrypted BSON.
     pub fn build_explicit_decrypt(self, msg: &[u8]) -> Result<Ctx> {
-        let bson_bin = bson::Binary {
-            subtype: bson::spec::BinarySubtype::Encrypted,
+        let bson_bin = crate::bson::Binary {
+            subtype: crate::bson::spec::BinarySubtype::Encrypted,
             bytes: msg.into(),
         };
         let mut bin: BinaryBuf = rawdoc! { "v": bson_bin }.into();

--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -21,6 +21,18 @@ pub use hooks::*;
 use native::OwnedPtr;
 use once_cell::sync::Lazy;
 
+#[cfg(all(feature = "bson-2", feature = "bson-3"))]
+compile_error!("Only one of the bson-2 and bson-3 features should be enabled.");
+
+#[cfg(not(any(feature = "bson-2", feature = "bson-3")))]
+compile_error!("One of the bson-2 and bson-3 features must be enabled.");
+
+#[cfg(feature = "bson-2")]
+use bson_2 as bson;
+
+#[cfg(feature = "bson-3")]
+pub(crate) use bson_3 as bson;
+
 /// Returns the version string for libmongocrypt.
 pub fn version() -> &'static str {
     let c_version = unsafe { CStr::from_ptr(sys::mongocrypt_version(ptr::null_mut())) };
@@ -253,7 +265,7 @@ impl CryptBuilder {
         unsafe {
             let ok = sys::mongocrypt_setopt_retry_kms(*self.inner.borrow(), enable);
             if !ok {
-                return Err(self.status().as_error())
+                return Err(self.status().as_error());
             }
         }
         Ok(self)
@@ -264,7 +276,7 @@ impl CryptBuilder {
         unsafe {
             let ok = sys::mongocrypt_setopt_key_expiration(*self.inner.borrow(), expiration_ms);
             if !ok {
-                return Err(self.status().as_error())
+                return Err(self.status().as_error());
             }
         }
         Ok(self)

--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -31,7 +31,7 @@ compile_error!("One of the bson-2 and bson-3 features must be enabled.");
 use bson_2 as bson;
 
 #[cfg(feature = "bson-3")]
-pub(crate) use bson_3 as bson;
+use bson_3 as bson;
 
 /// Returns the version string for libmongocrypt.
 pub fn version() -> &'static str {

--- a/mongocrypt/src/test.rs
+++ b/mongocrypt/src/test.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use bson::doc;
+use crate::bson::doc;
 
 use crate::ctx::Algorithm;
 use crate::error::Result;
@@ -69,7 +69,7 @@ fn ctx_setopts() -> Result<()> {
         .masterkey_aws("somewhere", "something")?
         .masterkey_aws_endpoint("example.com")?
         .contention_factor(10)?
-        .index_key_id(&bson::Uuid::new())?
+        .index_key_id(&crate::bson::Uuid::new())?
         .query_type("equality")?;
 
     Ok(())

--- a/mongocrypt/src/test/example_state_machine.rs
+++ b/mongocrypt/src/test/example_state_machine.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::Read, path::Path};
 
-use bson::{Bson, Document, RawBson, RawDocument, RawDocumentBuf};
+use crate::bson::{Bson, Document, RawBson, RawDocument, RawDocumentBuf};
 
 use crate::{
     ctx::{Algorithm, Ctx, State},
@@ -141,7 +141,7 @@ fn explicit_encryption_decryption() -> Result<()> {
     // Encryption
     let key_doc = load_doc_from_json("../testdata/key-document.json");
     let key_bytes = match key_doc.get("_id").unwrap() {
-        Bson::Binary(bson::Binary { bytes, .. }) => bytes,
+        Bson::Binary(crate::bson::Binary { bytes, .. }) => bytes,
         _ => panic!("non-binary bson"),
     };
     let mut ctx = crypt


### PR DESCRIPTION
RUST-2217

This is required before it can be done for the main driver crate, and simpler than it'll be for that because this crate is still 0.x so we can just do a breaking change.