### PR TITLE
RUST-2217 Make bson-2 and bson-3 nonexclusive

### DIFF
--- a/mongocrypt/src/lib.rs
+++ b/mongocrypt/src/lib.rs
@@ -21,13 +21,10 @@ pub use hooks::*;
 use native::OwnedPtr;
 use once_cell::sync::Lazy;
 
-#[cfg(all(feature = "bson-2", feature = "bson-3"))]
-compile_error!("Only one of the bson-2 and bson-3 features should be enabled.");
-
 #[cfg(not(any(feature = "bson-2", feature = "bson-3")))]
 compile_error!("One of the bson-2 and bson-3 features must be enabled.");
 
-#[cfg(feature = "bson-2")]
+#[cfg(all(feature = "bson-2", not(feature = "bson-3")))]
 use bson_2 as bson;
 
 #[cfg(feature = "bson-3")]


### PR DESCRIPTION
RUST-2217

This modifies https://github.com/mongodb/libmongocrypt-rust/commit/30e0b8200a1a4e6f35dcda08d1d5db43d4d43d99 to make the `bson-2` and `bson-3` features non-exclusive, with `bson-3` having precedence when both are active.  We did a similar thing for ssl providers in the driver crate; while it's pointless to have both active and just pulls in the dependency for no gain, it allows features to be strictly additive and means that things like `--all-features` work without generating compile errors.